### PR TITLE
luci-app-mtwifi: add wifi relay support (#5168)

### DIFF
--- a/package/lean/mt/drivers/mt7603e/Makefile
+++ b/package/lean/mt/drivers/mt7603e/Makefile
@@ -36,6 +36,7 @@ TAR_CMD=$(HOST_TAR) -C $(1)/ $(TAR_OPTIONS)
 define KernelPackage/mt7603e
   CATEGORY:=Kernel modules
   TITLE:=MTK wifi AP driver
+  DEPENDS:=@TARGET_ramips
   FILES:=$(PKG_BUILD_DIR)/mt7603_wifi_ap/mt7603e.ko
   SUBMENU:=Wireless Drivers
   MENU:=1

--- a/package/lean/mt/drivers/mt7612e/Makefile
+++ b/package/lean/mt/drivers/mt7612e/Makefile
@@ -24,6 +24,7 @@ TAR_CMD=$(HOST_TAR) -C $(1)/ $(TAR_OPTIONS)
 define KernelPackage/mt76x2e
   CATEGORY:=Kernel modules
   TITLE:=MTK MT76x2e wifi AP driver
+  DEPENDS:=@TARGET_ramips
   FILES:=$(PKG_BUILD_DIR)/mt76x2_ap/mt76x2_ap.ko
   SUBMENU:=Wireless Drivers
   MENU:=1

--- a/package/lean/mt/drivers/mt_wifi/Makefile
+++ b/package/lean/mt/drivers/mt_wifi/Makefile
@@ -21,7 +21,7 @@ define Package/mt_wifi
   SECTION:=net
   CATEGORY:=Network
   TITLE:=MTK wifi AP config
-  DEPENDS:=@TARGET_ramips
+  DEPENDS:=@TARGET_ramips +wireless-tools
   SUBMENU:=Wireless
 endef
 

--- a/package/lean/mt/luci-app-mtwifi/Makefile
+++ b/package/lean/mt/luci-app-mtwifi/Makefile
@@ -7,7 +7,7 @@ LUCI_TITLE:=LuCI support for mt wifi driver
 LUCI_DEPENDS:=@TARGET_ramips +mt_wifi
 LUCI_PKGARCH:=all
 PKG_VERSION:=1
-PKG_RELEASE:=12
+PKG_RELEASE:=15
 
 define Package/luci-app-mtwifi/conffiles
 /etc/wireless/mt7615/

--- a/package/lean/mt/luci-app-mtwifi/luasrc/view/admin_mtk/mtk_wifi_apcli.htm
+++ b/package/lean/mt/luci-app-mtwifi/luasrc/view/admin_mtk/mtk_wifi_apcli.htm
@@ -56,7 +56,7 @@ local debug = 0
         iwpriv <%=vifname%> set ApCliEnable=1              // enable sta mode</pre>
         <br />
         <p class="left">
-            <input id="scan" type="button" class="cbi-button cbi-button-find" onclick="get_ap_list('<%=vifname%>')" value="Scan Wireless Network" />
+            <input id="scan" type="button" class="cbi-button cbi-button-find" onclick="get_ap_list('<%=vifname%>')" value="扫描网络" />
         </p>
         <div id="loading" style="display:none;">
         <img src="<%=resource%>/icons/loading.gif" alt="<%:Loading%>" style="vertical-align:middle;" />
@@ -66,7 +66,7 @@ local debug = 0
         </div>
     </fieldset>
     <fieldset class="cbi-section" id="vif-cfg-apcli-config">
-        <legend> <a name="apcli_cfg_section"> Connection Configurations</a> </legend>
+        <legend> <a name="apcli_cfg_section"> 中继参数</a> </legend>
         <table class="cbi-section-table">
             <tbody>
             <tr><th class="th1"></th><th></th><th></th></tr>
@@ -79,21 +79,21 @@ local debug = 0
                 <td></td>
             </tr>
             <tr>
-                <td>Root AP SSID</td>
+                <td>上级无线名称</td>
                 <td>
                     <input type="text" name="ApCliSsid" id="ApCliSsid" value="<%=cfgs.ApCliSsid%>"/>
                 </td>
                 <td></td>
             </tr>
             <tr>
-                <td>Root AP Channel</td>
+                <td>上级无线信道</td>
                 <td>
                     <input type="text" name="Channel" id="Channel" value="<%=dev.Channel%>"/>
                 </td>
-                <td> <span style="color:red;">This will overwrite ap channel.</span></td>
+                <td> <span style="color:red;">将会重置当前信道</span></td>
             </tr>
             <tr>
-                <td>Root AP Authentication Mode</td>
+                <td>上级无线加密模式</td>
                 <td>
                     <select name="ApCliAuthMode" cfg="ApCliAuthMode" id="ApCliAuthMode" onchange="ApCliAuthMode_onchange(this.options[this.options.selectedIndex].value)">
                         <% for _,v in ipairs(dev.ApCliAuthModeList) do %>
@@ -117,7 +117,7 @@ local debug = 0
             </tbody>
             <tbody id="apcli_wpa"<% if cfgs.ApCliAuthMode ~= "WPA2PSK" then %> style="display: none;"<% end %>>
             <tr>
-                <td>Root AP Encryption</td>
+                <td>上级无线加密算法</td>
                 <td>
                     <select name="wpa_ApCliEncrypType" id="wpa_ApCliEncrypType" >
                     <% for _, v in ipairs(dev.WPA_Enc_List) do %>
@@ -129,7 +129,7 @@ local debug = 0
                 <td></td>
             </tr>
             <tr>
-                <td>Root AP WPA Key</td>
+                <td>上级无线密码</td>
                 <td>
                     <input type="text" name="ApCliWPAPSK" id="ApCliWPAPSK" value="<%=cfgs.ApCliWPAPSK%>"/>
                 </td>
@@ -138,7 +138,7 @@ local debug = 0
             </tbody>
             <tbody id="apcli_wep"<% if cfgs.ApCliAuthMode ~= "WEP" then %> style="display: none;"<% end %>>
             <tr>
-                <td>Root AP Encryption</td>
+                <td>上级无线加密算法</td>
                 <td>
                     <select name="wep_ApCliEncrypType" id="wep_ApCliEncrypType" >
                     <% for _, v in ipairs(dev.WEP_Enc_List) do %>
@@ -150,7 +150,7 @@ local debug = 0
                 <td></td>
             </tr>
             <tr>
-                <td>Root AP WEP Key</td>
+                <td>上级无线密码</td>
                 <td>
                     <input type="text" name="ApCliKey1Str" id="ApCliKey1Str" value="<%=cfgs.ApCliKey1Str%>"/>
                     <input type="hidden" name="ApCliDefaultKeyID" value="1"/>
@@ -162,9 +162,10 @@ local debug = 0
     </fieldset>
 
     <div class="cbi-page-actions" id="apcli_form_buttons">
-        <input class="cbi-button cbi-button-apply" value="Reload" type="button" onclick='wifi_reload("<%=luci.dispatcher.build_url("admin", "network", "wifi", "reload", devname)%>");' />
-        <input class="cbi-button cbi-button-apply" value="Save" type="submit" />
-        <input class="cbi-button cbi-button-reset" value="Reset" type="reset" />
+        <input class="cbi-button cbi-button-apply" value="重启无线" type="button" onclick='wifi_reload("<%=luci.dispatcher.build_url("admin", "network", "wifi", "reload", devname)%>");' />
+        <input class="cbi-button cbi-button-apply" value="保存设置" type="submit" />
+        <input class="cbi-button cbi-button-apply" value="连接中继" type="button" onclick='wifi_reload("<%=luci.dispatcher.build_url("admin", "network", "wifi", "apcli_connect", dev.devname, dev.apcli.vifname)%>")' />
+        <input class="cbi-button cbi-button-reset" value="重置设置" type="reset" />
     </div>
 </form>
 
@@ -230,17 +231,17 @@ local debug = 0
 
         var tr = table.insertRow(0);
         var td0 = tr.insertCell(0);
-        td0.innerHTML = '<strong>SSID</strong>';
+        td0.innerHTML = '<strong>无线名称</strong>';
         var td1 = tr.insertCell(1);
-        td1.innerHTML = '<strong>Channel</strong>';
+        td1.innerHTML = '<strong>信道</strong>';
         var td2 = tr.insertCell(2);
         td2.innerHTML = '<strong>BSSID</strong>';
         var td3 = tr.insertCell(3);
-        td3.innerHTML = '<strong>Security</strong>';
+        td3.innerHTML = '<strong>加密方式</strong>';
         var td4 = tr.insertCell(4);
-        td4.innerHTML = '<strong>RSSI</strong>';
+        td4.innerHTML = '<strong>信号强度</strong>';
         var td5 = tr.insertCell(5);
-        td5.innerHTML = '<strong>Action</strong>';
+        td5.innerHTML = '<strong>动作</strong>';
 
         var div = document.getElementById('aplist');
         div.innerHTML = "";

--- a/package/lean/mt/luci-app-mtwifi/luasrc/view/admin_mtk/mtk_wifi_overview.htm
+++ b/package/lean/mt/luci-app-mtwifi/luasrc/view/admin_mtk/mtk_wifi_overview.htm
@@ -81,11 +81,50 @@ local devs = mtkwifi.get_all_devs()
                         <input class="cbi-button cbi-button-apply" style="width:100px" title="禁用无线" value="启用" type="button" onclick="location.href='<%=luci.dispatcher.build_url("admin", "network", "wifi", "vif_enable", vif.vifname)%>'" />
                         <% end %>
                         <input class="cbi-button cbi-button-edit" style="width:100px" title="修改无线基本设置" value="基本设置" type="button" onclick="location.href='<%=luci.dispatcher.build_url("admin", "network", "wifi", "vif_cfg_view", dev.devname, vif.vifname)%>'" />
+                        <% if dev.apcli.state == "down" then %>
+                        <input class="cbi-button cbi-button-apply" style="width:100px" title="启用无线" value="启用中继" type="button" onclick="location.href='<%=luci.dispatcher.build_url("admin", "network", "wifi", "vif_enable", dev.apcli.vifname)%>'" />
+                        <% end %>
                         <input class="cbi-button cbi-button-remove" style="width:100px" title="删除网络" value="移除" type="button" onclick="location.href='<%=luci.dispatcher.build_url("admin", "network", "wifi", "vif_del", dev.devname, vif.vifname)%>'" />
                     </td>
                 </tr>
                 <% end %>
                 <!-- /network list -->
+                <!-- apcli list -->
+                <% if dev.apcli then %>
+                    <% if dev.apcli.state == "up" then %>
+                    <tr>
+                        <td></td>
+                        <td class="cbi-value-field" style="width:16px; padding:3px">
+                            <% if dev.apcli.state == "up" then %>
+                            <img src="/luci-static/resources/icons/signal-75-100.png" />
+                            <% else %>
+                            <img src="/luci-static/resources/icons/signal-none.png" />
+                            <% end %>
+                        </td>
+                        <td class="cbi-value-field" style="vertical-align:middle; text-align:left; padding:3px"><strong>接口:</strong> <%=dev.apcli.devname%> | <strong>类型:</strong> STA | <strong>状态:</strong> <%=dev.apcli.status%>
+                            <br/>
+                            <% if dev.apcli.status == "Connected" then %>
+                            <strong>BSSID:</strong>:<%=dev.apcli.bssid%> |
+                            <strong>SSID:</strong>:<%=dev.apcli.ssid%>
+                            <% else %>
+                            Wireless is disabled or not associated
+                            <% end %>
+                        </td>
+                        <td style="text-align:right">
+                            <input class="cbi-button cbi-button-reset" style="width:100px" title="禁用无线" value="禁用中继" type="button" onclick="location.href='<%=luci.dispatcher.build_url("admin", "network", "wifi", "vif_disable", dev.apcli.vifname)%>'" />
+
+                            <% if dev.apcli.status == "Connected" then %>
+                            <input class="cbi-button cbi-button-remove" style="width:100px" title="重启无线" value="断开中继" type="button" onclick='wifi_reload("<%=luci.dispatcher.build_url("admin", "network", "wifi", "apcli_disconnect", dev.devname, dev.apcli.vifname)%>")' />
+                            <% else %>
+                            <input class="cbi-button cbi-button-reload" style="width:100px" title="重启无线" value="连接中继" type="button" onclick='wifi_reload("<%=luci.dispatcher.build_url("admin", "network", "wifi", "apcli_connect", dev.devname, dev.apcli.vifname)%>")' />
+                            <% end %>
+
+                            <input class="cbi-button cbi-button-edit" style="width:100px" title="配置无线设置" value="中继设置" type="button" onclick="location.href='<%=luci.dispatcher.build_url("admin", "network", "wifi", "apcli_cfg_view", dev.devname, dev.apcli.vifname)%>'" />
+                        </td>
+                    </tr>
+                    <% end %>
+                <% end %>
+                <!-- /apcli list -->
             </tbody>
         </table>
     </fieldset>

--- a/package/lean/mt/luci-app-mtwifi/root/usr/lib/lua/mtkwifi.lua
+++ b/package/lean/mt/luci-app-mtwifi/root/usr/lib/lua/mtkwifi.lua
@@ -856,7 +856,9 @@ function mtkwifi.scan_ap(vifname)
             tmp.rssi = mtkwifi.__trim(string.sub(line, xx.Signal[1], xx.Signal[1]+xx.Signal[2]))
             tmp.extch = mtkwifi.__trim(string.sub(line, xx.ExtCh[1], xx.ExtCh[1]+xx.ExtCh[2]))
             tmp.mode = mtkwifi.__trim(string.sub(line, xx.Mode[1], xx.Mode[1]+xx.Mode[2]))
-            tmp.wps = mtkwifi.__trim(string.sub(line, xx.WPS[1], xx.WPS[1]+xx.WPS[2]))
+            if (xx.WPS[1] ~= nil and xx.WPS[2] ~= nil) then
+                tmp.wps = mtkwifi.__trim(string.sub(line, xx.WPS[1], xx.WPS[1]+xx.WPS[2]))
+            end
             tmp.nt = mtkwifi.__trim(string.sub(line, xx.NT[1], xx.NT[1]+xx.NT[2]))
             table.insert(aplist, tmp)
         end


### PR DESCRIPTION
* luci-app-mtwifi: add wifi relay support

Source code: Nossiac/mtk-openwrt-feeds
Based on commit 'wireless: wext: remove ndo_do_ioctl fallback'

* luci-app-mtwifi: fix ap-scan failed

* luci-app-mtwifi: show overview when relay is enabled

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
